### PR TITLE
Use env vars for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Volume Profile Bot
+
+This repository contains a trading bot that relies on the MetaTrader5 (MT5) Python API.
+
+## Environment Variables
+
+Before running `bot.py`, set the following environment variables so the bot can
+authenticate with your MT5 account:
+
+- `MT5_LOGIN` – numeric login ID for the MT5 account
+- `MT5_PASSWORD` – password associated with the login
+- `MT5_SERVER` – name of the MT5 trading server
+
+These variables are read at runtime and are required for initialization.

--- a/bot.py
+++ b/bot.py
@@ -15,9 +15,9 @@ from decimal import Decimal
 sys.stdout.reconfigure(encoding='utf-8')
 
 # === CONFIGURATION ===
-LOGIN = 204215535
-PASSWORD = "Mgi@2005"
-SERVER = "Exness-MT5Trial7"
+LOGIN = int(os.getenv("MT5_LOGIN", "0"))
+PASSWORD = os.getenv("MT5_PASSWORD", "")
+SERVER = os.getenv("MT5_SERVER", "")
 SYMBOL = "XAUUSDm"
 TIMEFRAME = mt5.TIMEFRAME_M1
 


### PR DESCRIPTION
## Summary
- source MT5 credentials from environment variables
- document environment variables in README

## Testing
- `python -m py_compile bot.py range.py`

------
https://chatgpt.com/codex/tasks/task_e_684918667af8832cb0472208d9703b41